### PR TITLE
修改写入文件时，文件路径判断的逻辑

### DIFF
--- a/JKSwiftExtension/Classes/JKSwiftExtesion/FoundationExtension/FileManager+Extension.swift
+++ b/JKSwiftExtension/Classes/JKSwiftExtesion/FoundationExtension/FileManager+Extension.swift
@@ -234,7 +234,7 @@ public extension JKPOP where Base: FileManager {
     /// - Returns: 写入的结果
     @discardableResult
     static func writeToFile(writeType: FileWriteType, content: Any, writePath: String) -> (isSuccess: Bool, error: String) {
-        guard judgeFileOrFolderExists(filePath: writePath) else {
+        guard judgeFileOrFolderExists(filePath: directoryAtPath(path: writePath)) else {
             // 不存在的文件路径
             return (false, "不存在的文件路径")
         }


### PR DESCRIPTION
目前的逻辑：先判断目标文件路径是否存在，不存在则返回false，存在则返回true，然后再写入文件。但是写入文件时，如果文件已存在则不能写入，会提示文件已存在。

修改为：先判断目标文件路径的前一个路径是否存在，如果存在则返回true，并写入文件，如果不存在则返回false